### PR TITLE
fix: get proxy ip also need user-agent

### DIFF
--- a/DirScan.py
+++ b/DirScan.py
@@ -117,7 +117,7 @@ class DirScan:
     def get_ip(self):
     # def get_ip():
         urls = "https://www.kuaidaili.com/free/inha/1/"
-        str_html = requests.get(urls)
+        str_html = requests.get(urls, headers=self.get_user_agent())
         str_text = str_html.text
         regex = re.compile('<td data-title="IP">(.*)</td>')
         ips = regex.findall(str_text)


### PR DESCRIPTION
执行：
python DirScan.py baidu.com ./dictionary/

报错：


          ___  __       _  _
         |__ \/_ |     | |(_)
            ) || |   __| | _  _ __   ___   __ _   ___  _ __
           / / | |  / _` || || '__| / __| / _` | / __|| '_ \
          / /_ | | | (_| || || |    \__ \| (_| || (__ | | | |
         |____||_|  \__,_||_||_|    |___/ \__,_| \___||_| |_|

输入的路径为./dictionary/
......
urllib3.exceptions.MaxRetryError: HTTPSConnectionPool(host='www.kuaidaili.com', port=443): Max retries exceeded with url: /free/inha/1/ (Caused by ProxyError('Cannot connect to proxy.', RemoteDisconnected('Remote end closed connection without response')))

原因：请求www.kuaidaili.com需要带上UA